### PR TITLE
Add interactive leaderboard with architecture classification and filters

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@ footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.
     <p class="sub">Benchmarking LLM-Based Voice Assistants &middot; 38 Models &middot; 4 Architecture Types &middot; Click cards to filter</p>
     <div class="links">
       <a class="primary" href="https://github.com/MatthewCYM/VoiceBench" target="_blank">GitHub &rarr;</a>
-      <a class="secondary" href="https://arxiv.org/abs/2410.17196" target="_blank">Paper (ICLR 2025) &rarr;</a>
+      <a class="secondary" href="https://arxiv.org/abs/2410.17196" target="_blank">Paper (TACL) &rarr;</a>
       <a class="secondary" href="https://huggingface.co/datasets/hlt-lab/voicebench" target="_blank">Dataset &rarr;</a>
     </div>
   </div>
@@ -455,7 +455,7 @@ footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.
     <p>
       A comprehensive benchmark for LLM-based voice assistants across <strong>10 evaluation dimensions</strong>,
       covering diverse speaker characteristics, environmental factors, and content variations.
-      Apache 2.0 &middot; <a href="https://arxiv.org/abs/2410.17196" target="_blank"><strong>ICLR 2025</strong></a>.
+      Apache 2.0 &middot; <a href="https://arxiv.org/abs/2410.17196" target="_blank"><strong>TACL</strong></a>.
       To submit your model, open an <a href="https://github.com/MatthewCYM/VoiceBench/issues">issue</a> on GitHub.
     </p>
     <p style="margin-top:10px;font-size:.82rem;color:#94a3b8">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,578 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>VoiceBench Leaderboard — Interactive Voice Assistant Rankings</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;background:#f8fafc;color:#1a1a2e;line-height:1.6;-webkit-font-smoothing:antialiased}
+a{color:#3b82f6;text-decoration:none}a:hover{text-decoration:underline}
+
+/* Header */
+.hero{background:#fff;border-bottom:1px solid #e2e8f0;padding:40px 0 32px;text-align:center}
+.hero h1{font-size:2rem;font-weight:800;letter-spacing:-.03em;margin-bottom:4px;color:#0f172a}
+.hero h1 span{background:linear-gradient(135deg,#3b82f6,#6366f1);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.hero .sub{font-size:.9rem;color:#64748b;margin-bottom:14px}
+.hero .links{display:flex;gap:10px;justify-content:center;flex-wrap:wrap}
+.hero .links a{display:inline-flex;align-items:center;gap:4px;font-weight:600;font-size:.82rem;padding:6px 16px;border-radius:6px;transition:all .15s}
+.hero .links a.primary{background:#3b82f6;color:#fff}.hero .links a.primary:hover{background:#2563eb;text-decoration:none}
+.hero .links a.secondary{border:1px solid #3b82f6;color:#3b82f6}.hero .links a.secondary:hover{background:#eff6ff;text-decoration:none}
+.container{max-width:1400px;margin:0 auto;padding:0 24px}
+section{padding:32px 0}section+section{padding-top:0}
+
+/* Architecture filter cards */
+.filter-cards{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-bottom:6px}
+.fc{background:#fff;border:2px solid #e2e8f0;border-radius:12px;padding:14px 12px;cursor:pointer;transition:all .2s;text-align:center;user-select:none}
+.fc:hover{border-color:#94a3b8;transform:translateY(-1px);box-shadow:0 4px 12px rgba(0,0,0,.06)}
+.fc.active{transform:translateY(-2px);box-shadow:0 6px 20px rgba(0,0,0,.1)}
+.fc .fc-count{font-size:1.5rem;font-weight:800;line-height:1}
+.fc .fc-label{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;margin-top:4px;color:#94a3b8}
+.fc .fc-desc{font-size:.65rem;color:#94a3b8;margin-top:3px;line-height:1.3}
+.fc .fc-best{font-size:.62rem;color:#94a3b8;margin-top:6px;padding-top:6px;border-top:1px solid #f1f5f9}
+.fc .fc-best strong{color:#64748b}
+
+/* Card color themes */
+.fc[data-arch="all"].active{border-color:#334155;background:#334155}
+.fc[data-arch="all"].active .fc-count,.fc[data-arch="all"].active .fc-label{color:#fff}
+.fc[data-arch="all"].active .fc-desc,.fc[data-arch="all"].active .fc-best,.fc[data-arch="all"].active .fc-best strong{color:#cbd5e1}
+
+.fc[data-arch="fullduplex"]{border-color:#d1fae5}.fc[data-arch="fullduplex"] .fc-count{color:#059669}
+.fc[data-arch="fullduplex"].active{border-color:#059669;background:#059669}
+.fc[data-arch="fullduplex"].active .fc-count,.fc[data-arch="fullduplex"].active .fc-label{color:#fff}
+.fc[data-arch="fullduplex"].active .fc-desc,.fc[data-arch="fullduplex"].active .fc-best,.fc[data-arch="fullduplex"].active .fc-best strong{color:#d1fae5}
+
+.fc[data-arch="omni_hd"]{border-color:#e2e8f0}.fc[data-arch="omni_hd"] .fc-count{color:#475569}
+.fc[data-arch="omni_hd"].active{border-color:#475569;background:#475569}
+.fc[data-arch="omni_hd"].active .fc-count,.fc[data-arch="omni_hd"].active .fc-label{color:#fff}
+.fc[data-arch="omni_hd"].active .fc-desc,.fc[data-arch="omni_hd"].active .fc-best,.fc[data-arch="omni_hd"].active .fc-best strong{color:#cbd5e1}
+
+.fc[data-arch="audiollm"]{border-color:#fef3c7}.fc[data-arch="audiollm"] .fc-count{color:#d97706}
+.fc[data-arch="audiollm"].active{border-color:#d97706;background:#d97706}
+.fc[data-arch="audiollm"].active .fc-count,.fc[data-arch="audiollm"].active .fc-label{color:#fff}
+.fc[data-arch="audiollm"].active .fc-desc,.fc[data-arch="audiollm"].active .fc-best,.fc[data-arch="audiollm"].active .fc-best strong{color:#fef3c7}
+
+.fc[data-arch="cascaded"]{border-color:#dbeafe}.fc[data-arch="cascaded"] .fc-count{color:#2563eb}
+.fc[data-arch="cascaded"].active{border-color:#2563eb;background:#2563eb}
+.fc[data-arch="cascaded"].active .fc-count,.fc[data-arch="cascaded"].active .fc-label{color:#fff}
+.fc[data-arch="cascaded"].active .fc-desc,.fc[data-arch="cascaded"].active .fc-best,.fc[data-arch="cascaded"].active .fc-best strong{color:#dbeafe}
+
+/* Open/closed toggle pills */
+.open-toggle{display:flex;gap:8px;align-items:center;margin-bottom:14px}
+.open-toggle .ot-label{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:#94a3b8}
+.pill{display:inline-flex;align-items:center;gap:4px;padding:5px 12px;border-radius:100px;font-size:.78rem;font-weight:600;cursor:pointer;border:1.5px solid #e2e8f0;background:#fff;color:#64748b;transition:all .15s;user-select:none}
+.pill:hover{border-color:#94a3b8}.pill.active{color:#fff}
+.pill[data-val="all"].active{background:#334155;border-color:#334155}
+.pill[data-val="open"].active{background:#16a34a;border-color:#16a34a}
+.pill[data-val="closed"].active{background:#dc2626;border-color:#dc2626}
+
+/* Filter summary bar */
+.filter-summary{font-size:.84rem;color:#475569;padding:8px 14px;background:#f1f5f9;border-radius:8px;margin-bottom:14px;display:none;line-height:1.5}
+.filter-summary strong{color:#0f172a}
+
+/* Table */
+.table-wrap{background:#fff;border:1px solid #e2e8f0;border-radius:10px;overflow-x:auto}
+.table-wrap table{width:100%;border-collapse:collapse;font-size:.8rem;white-space:nowrap}
+.table-wrap thead{background:#f8fafc;position:sticky;top:0;z-index:2}
+.table-wrap th{text-align:center;padding:10px 8px;font-weight:600;font-size:.68rem;text-transform:uppercase;letter-spacing:.04em;color:#64748b;border-bottom:2px solid #e2e8f0}
+.table-wrap th:nth-child(1),.table-wrap th:nth-child(2){text-align:left}
+.table-wrap td{padding:8px 8px;border-bottom:1px solid #f1f5f9;text-align:center}
+.table-wrap td:nth-child(1),.table-wrap td:nth-child(2){text-align:left}
+.table-wrap tbody tr:last-child td{border-bottom:none}
+.table-wrap tbody tr:hover{background:#f8fafc}
+.table-wrap tbody tr.hidden{display:none}
+
+/* Rank badges */
+.rank{display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;font-weight:700;font-size:.8rem}
+.rank-1{background:#f59e0b;color:#fff}.rank-2{background:#94a3b8;color:#fff}.rank-3{background:#c2884d;color:#fff}
+.rank-default{background:#f1f5f9;color:#64748b}
+
+/* Model cell with badges */
+.model-cell{white-space:normal !important;min-width:240px}
+.model-name{font-weight:600;display:block;margin-bottom:2px}
+.badges{display:flex;flex-wrap:wrap;gap:3px}
+.badge{display:inline-block;font-size:.58rem;font-weight:700;padding:1px 6px;border-radius:100px;letter-spacing:.02em}
+.b-fd{background:#059669;color:#fff}
+.b-cas{background:#2563eb;color:#fff}
+.b-allm{background:#d97706;color:#fff}
+.b-omni{background:#475569;color:#fff}
+.b-open{background:#dcfce7;color:#166534}
+.b-closed{background:#fee2e2;color:#991b1b}
+
+/* Score cells */
+.dim{color:#64748b;font-size:.8rem}
+.overall-score{font-weight:700;color:#0f172a;font-size:.88rem;border-left:2px solid #f1f5f9 !important}
+.cat-rank-cell{font-weight:600;font-size:.82rem;color:#64748b;min-width:100px;border-left:2px solid #f1f5f9 !important;white-space:nowrap}
+.cr-cat{font-size:.95rem;font-weight:800}.cr-sep{color:#cbd5e1;margin:0 3px}.cr-orig{font-size:.72rem;color:#94a3b8;font-weight:500}
+
+/* Row highlights by architecture */
+.row-fd td{background:#f0fdf4 !important}.row-fd:hover td{background:#dcfce7 !important}
+
+.table-note{padding:10px 16px;font-size:.74rem;color:#94a3b8;border-top:1px solid #f1f5f9}
+
+/* About card */
+.about-card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:20px 24px}
+.about-card h2{font-size:1.1rem;font-weight:700;margin-bottom:8px;color:#0f172a}
+.about-card p{color:#475569;font-size:.88rem;line-height:1.7}
+
+/* Legend */
+.legend{display:flex;flex-wrap:wrap;gap:16px;margin-bottom:14px;font-size:.75rem;color:#64748b}
+.legend-item{display:flex;align-items:center;gap:5px}
+.legend-swatch{width:14px;height:14px;border-radius:4px;display:inline-block}
+
+footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.78rem;color:#94a3b8;margin-top:16px;background:#fff}
+
+@media(max-width:768px){
+  .hero h1{font-size:1.4rem}
+  .filter-cards{grid-template-columns:repeat(3,1fr)}
+  .table-wrap table{min-width:900px}
+}
+@media(max-width:500px){
+  .filter-cards{grid-template-columns:1fr 1fr}
+}
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="container">
+    <h1>VoiceBench &mdash; <span>Leaderboard</span></h1>
+    <p class="sub">Benchmarking LLM-Based Voice Assistants &middot; 38 Models &middot; 4 Architecture Types &middot; Click cards to filter</p>
+    <div class="links">
+      <a class="primary" href="https://github.com/MatthewCYM/VoiceBench" target="_blank">GitHub &rarr;</a>
+      <a class="secondary" href="https://arxiv.org/abs/2410.17196" target="_blank">Paper (ICLR 2025) &rarr;</a>
+      <a class="secondary" href="https://huggingface.co/datasets/hlt-lab/voicebench" target="_blank">Dataset &rarr;</a>
+    </div>
+  </div>
+</header>
+
+<div class="container">
+<section>
+
+  <!-- Architecture filter cards -->
+  <div class="filter-cards">
+    <div class="fc active" data-arch="all">
+      <div class="fc-count">38</div>
+      <div class="fc-label">All Models</div>
+      <div class="fc-desc">Full leaderboard</div>
+      <div class="fc-best">#1: <strong>Ultravox-GLM-4P7 (88.9)</strong></div>
+    </div>
+    <div class="fc" data-arch="cascaded">
+      <div class="fc-count">5</div>
+      <div class="fc-label">Cascaded</div>
+      <div class="fc-desc">Separate ASR + LLM pipeline</div>
+      <div class="fc-best">#1: <strong>Whisper + GPT-4o (87.8)</strong></div>
+    </div>
+    <div class="fc" data-arch="audiollm">
+      <div class="fc-count">11</div>
+      <div class="fc-label">Audio-LLM</div>
+      <div class="fc-desc">Audio encoder + LLM, text output</div>
+      <div class="fc-best">#1: <strong>Ultravox-GLM-4P7 (88.9)</strong></div>
+    </div>
+    <div class="fc" data-arch="omni_hd">
+      <div class="fc-count">20</div>
+      <div class="fc-label">Omni</div>
+      <div class="fc-desc">Speech-in &amp; speech-out, turn-based</div>
+      <div class="fc-best">#1: <strong>GPT-4o-Audio (86.8)</strong></div>
+    </div>
+    <div class="fc" data-arch="fullduplex">
+      <div class="fc-count">2</div>
+      <div class="fc-label">S2S / Full-Duplex</div>
+      <div class="fc-desc">Simultaneous listen &amp; speak</div>
+      <div class="fc-best">#1: <strong>Freeze-Omni (55.2)</strong></div>
+    </div>
+  </div>
+
+  <!-- Open / Closed toggle -->
+  <div class="open-toggle">
+    <span class="ot-label">Weights:</span>
+    <span class="pill active" data-val="all" id="pill-all">All (38)</span>
+    <span class="pill" data-val="open" id="pill-open">Open (35)</span>
+    <span class="pill" data-val="closed" id="pill-closed">Closed (3)</span>
+  </div>
+
+  <!-- Legend -->
+  <div class="legend">
+    <div class="legend-item"><span class="legend-swatch" style="background:#2563eb"></span> Cascaded</div>
+    <div class="legend-item"><span class="legend-swatch" style="background:#d97706"></span> Audio-LLM</div>
+    <div class="legend-item"><span class="legend-swatch" style="background:#475569"></span> Omni</div>
+    <div class="legend-item"><span class="legend-swatch" style="background:#059669"></span> S2S / Full-Duplex</div>
+    <div class="legend-item"><span class="legend-swatch" style="background:#dcfce7;border:1px solid #bbf7d0"></span> Open</div>
+    <div class="legend-item"><span class="legend-swatch" style="background:#fee2e2;border:1px solid #fecaca"></span> Closed</div>
+  </div>
+
+  <div class="filter-summary" id="filterSummary"></div>
+
+  <div class="table-wrap">
+    <table id="leaderboard">
+      <thead>
+        <tr>
+          <th style="width:48px">#</th><th>Model</th>
+          <th>AlpacaEval</th><th>CommonEval</th><th>WildVoice</th><th>SD-QA</th><th>MMSU</th><th>OBQA</th><th>BBH</th><th>IFEval</th><th>AdvBench</th>
+          <th>Overall</th><th style="min-width:100px">Cat. Rank</th>
+        </tr>
+      </thead>
+      <tbody>
+<tr data-arch="audiollm" data-open="open" data-rank="1" data-overall="88.86">
+<td><span class="rank rank-1" data-orig="1">1</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-GLM-4P7</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.87</td><td class="dim">4.30</td><td class="dim">4.55</td><td class="dim">84.15</td><td class="dim">83.82</td><td class="dim">94.72</td><td class="dim">87.16</td><td class="dim">76.26</td><td class="dim">99.23</td>
+<td class="overall-score">88.86</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="2" data-overall="88.79">
+<td><span class="rank rank-2" data-orig="2">2</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-GLM-4P7 (thinking)</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.69</td><td class="dim">4.05</td><td class="dim">4.21</td><td class="dim">88.57</td><td class="dim">87.15</td><td class="dim">95.01</td><td class="dim">89.78</td><td class="dim">80.99</td><td class="dim">98.46</td>
+<td class="overall-score">88.79</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="cascaded" data-open="closed" data-rank="3" data-overall="87.80">
+<td><span class="rank rank-3" data-orig="3">3</span></td>
+<td class="model-cell"><span class="model-name">Whisper-v3-large + GPT-4o</span><span class="badges"><span class="badge b-cas">Cascaded</span><span class="badge b-closed">Closed</span></span></td>
+<td class="dim">4.80</td><td class="dim">4.47</td><td class="dim">4.62</td><td class="dim">75.77</td><td class="dim">81.69</td><td class="dim">92.97</td><td class="dim">87.20</td><td class="dim">76.51</td><td class="dim">98.27</td>
+<td class="overall-score">87.80</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="4" data-overall="87.05">
+<td><span class="rank rank-default" data-orig="4">4</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-GLM-4P6</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.93</td><td class="dim">4.42</td><td class="dim">4.57</td><td class="dim">84.24</td><td class="dim">80.40</td><td class="dim">89.45</td><td class="dim">81.48</td><td class="dim">75.59</td><td class="dim">99.23</td>
+<td class="overall-score">87.05</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="closed" data-rank="5" data-overall="86.75">
+<td><span class="rank rank-default" data-orig="5">5</span></td>
+<td class="model-cell"><span class="model-name">GPT-4o-Audio</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-closed">Closed</span></span></td>
+<td class="dim">4.78</td><td class="dim">4.49</td><td class="dim">4.58</td><td class="dim">75.50</td><td class="dim">80.25</td><td class="dim">89.23</td><td class="dim">84.10</td><td class="dim">76.02</td><td class="dim">98.65</td>
+<td class="overall-score">86.75</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="closed" data-rank="6" data-overall="82.84">
+<td><span class="rank rank-default" data-orig="6">6</span></td>
+<td class="model-cell"><span class="model-name">GPT-4o-mini-Audio</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-closed">Closed</span></span></td>
+<td class="dim">4.75</td><td class="dim">4.24</td><td class="dim">4.40</td><td class="dim">67.36</td><td class="dim">72.90</td><td class="dim">84.84</td><td class="dim">81.50</td><td class="dim">72.90</td><td class="dim">98.27</td>
+<td class="overall-score">82.84</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="7" data-overall="81.81">
+<td><span class="rank rank-default" data-orig="7">7</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-v0.6-LLaMA-3.3-70B</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.69</td><td class="dim">4.26</td><td class="dim">4.38</td><td class="dim">82.60</td><td class="dim">69.20</td><td class="dim">86.40</td><td class="dim">78.80</td><td class="dim">61.50</td><td class="dim">91.20</td>
+<td class="overall-score">81.81</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="cascaded" data-open="open" data-rank="8" data-overall="79.23">
+<td><span class="rank rank-default" data-orig="8">8</span></td>
+<td class="model-cell"><span class="model-name">Parakeet-TDT-0.6b-V2 + Qwen3-8B</span><span class="badges"><span class="badge b-cas">Cascaded</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.68</td><td class="dim">4.46</td><td class="dim">4.35</td><td class="dim">47.47</td><td class="dim">59.10</td><td class="dim">80.00</td><td class="dim">77.90</td><td class="dim">78.99</td><td class="dim">99.81</td>
+<td class="overall-score">79.23</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="cascaded" data-open="open" data-rank="9" data-overall="77.48">
+<td><span class="rank rank-default" data-orig="9">9</span></td>
+<td class="model-cell"><span class="model-name">Whisper-v3-large + LLaMA-3.1-8B</span><span class="badges"><span class="badge b-cas">Cascaded</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.53</td><td class="dim">4.04</td><td class="dim">4.16</td><td class="dim">70.43</td><td class="dim">62.43</td><td class="dim">72.53</td><td class="dim">69.70</td><td class="dim">69.53</td><td class="dim">98.08</td>
+<td class="overall-score">77.48</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="10" data-overall="76.91">
+<td><span class="rank rank-default" data-orig="10">10</span></td>
+<td class="model-cell"><span class="model-name">Kimi-Audio</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.46</td><td class="dim">3.97</td><td class="dim">4.20</td><td class="dim">63.12</td><td class="dim">62.17</td><td class="dim">83.52</td><td class="dim">69.70</td><td class="dim">61.10</td><td class="dim">100.00</td>
+<td class="overall-score">76.91</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="cascaded" data-open="open" data-rank="11" data-overall="76.09">
+<td><span class="rank rank-default" data-orig="11">11</span></td>
+<td class="model-cell"><span class="model-name">Whisper-v3-turbo + LLaMA-3.1-8B</span><span class="badges"><span class="badge b-cas">Cascaded</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.55</td><td class="dim">4.02</td><td class="dim">4.12</td><td class="dim">58.23</td><td class="dim">62.04</td><td class="dim">72.09</td><td class="dim">69.10</td><td class="dim">71.12</td><td class="dim">98.46</td>
+<td class="overall-score">76.09</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="12" data-overall="74.86">
+<td><span class="rank rank-default" data-orig="12">12</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-v0.5-LLaMA-3.1-8B</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.59</td><td class="dim">4.11</td><td class="dim">4.28</td><td class="dim">58.68</td><td class="dim">54.16</td><td class="dim">68.35</td><td class="dim">67.80</td><td class="dim">66.51</td><td class="dim">98.65</td>
+<td class="overall-score">74.86</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="13" data-overall="72.09">
+<td><span class="rank rank-default" data-orig="13">13</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-v0.4.1-LLaMA-3.1-8B</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.55</td><td class="dim">3.90</td><td class="dim">4.12</td><td class="dim">53.35</td><td class="dim">47.17</td><td class="dim">65.27</td><td class="dim">66.30</td><td class="dim">66.88</td><td class="dim">98.46</td>
+<td class="overall-score">72.09</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="14" data-overall="71.32">
+<td><span class="rank rank-default" data-orig="14">14</span></td>
+<td class="model-cell"><span class="model-name">Baichuan-Omni-1.5</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.50</td><td class="dim">4.05</td><td class="dim">4.06</td><td class="dim">43.40</td><td class="dim">57.25</td><td class="dim">74.51</td><td class="dim">62.70</td><td class="dim">54.54</td><td class="dim">97.31</td>
+<td class="overall-score">71.32</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="15" data-overall="71.23">
+<td><span class="rank rank-default" data-orig="15">15</span></td>
+<td class="model-cell"><span class="model-name">MiniCPM-o</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.42</td><td class="dim">4.15</td><td class="dim">3.94</td><td class="dim">50.72</td><td class="dim">54.78</td><td class="dim">78.02</td><td class="dim">60.40</td><td class="dim">49.25</td><td class="dim">97.69</td>
+<td class="overall-score">71.23</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="cascaded" data-open="open" data-rank="16" data-overall="71.02">
+<td><span class="rank rank-default" data-orig="16">16</span></td>
+<td class="model-cell"><span class="model-name">Whisper-v3-turbo + LLaMA-3.2-3B</span><span class="badges"><span class="badge b-cas">Cascaded</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.45</td><td class="dim">3.82</td><td class="dim">4.04</td><td class="dim">49.28</td><td class="dim">51.37</td><td class="dim">60.66</td><td class="dim">63.90</td><td class="dim">69.71</td><td class="dim">98.08</td>
+<td class="overall-score">71.02</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="17" data-overall="69.27">
+<td><span class="rank rank-default" data-orig="17">17</span></td>
+<td class="model-cell"><span class="model-name">Baichuan-Audio</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.41</td><td class="dim">4.08</td><td class="dim">3.92</td><td class="dim">45.84</td><td class="dim">53.19</td><td class="dim">71.65</td><td class="dim">54.80</td><td class="dim">50.31</td><td class="dim">99.42</td>
+<td class="overall-score">69.27</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="18" data-overall="65.04">
+<td><span class="rank rank-default" data-orig="18">18</span></td>
+<td class="model-cell"><span class="model-name">MERaLiON</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.50</td><td class="dim">3.77</td><td class="dim">4.12</td><td class="dim">55.06</td><td class="dim">34.95</td><td class="dim">27.23</td><td class="dim">62.60</td><td class="dim">62.93</td><td class="dim">94.81</td>
+<td class="overall-score">65.04</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="19" data-overall="64.53">
+<td><span class="rank rank-default" data-orig="19">19</span></td>
+<td class="model-cell"><span class="model-name">VITA-1.5</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.21</td><td class="dim">3.66</td><td class="dim">3.48</td><td class="dim">38.88</td><td class="dim">52.15</td><td class="dim">71.65</td><td class="dim">55.30</td><td class="dim">38.14</td><td class="dim">97.69</td>
+<td class="overall-score">64.53</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="20" data-overall="64.32">
+<td><span class="rank rank-default" data-orig="20">20</span></td>
+<td class="model-cell"><span class="model-name">Phi-4-multimodal</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.81</td><td class="dim">3.82</td><td class="dim">3.56</td><td class="dim">39.78</td><td class="dim">42.19</td><td class="dim">65.93</td><td class="dim">61.80</td><td class="dim">45.35</td><td class="dim">100.00</td>
+<td class="overall-score">64.32</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="21" data-overall="59.42">
+<td><span class="rank rank-default" data-orig="21">21</span></td>
+<td class="model-cell"><span class="model-name">Ola</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.12</td><td class="dim">2.97</td><td class="dim">3.19</td><td class="dim">33.82</td><td class="dim">45.97</td><td class="dim">67.91</td><td class="dim">51.10</td><td class="dim">39.57</td><td class="dim">90.77</td>
+<td class="overall-score">59.42</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="22" data-overall="59.00">
+<td><span class="rank rank-default" data-orig="22">22</span></td>
+<td class="model-cell"><span class="model-name">Lyra-Base</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.85</td><td class="dim">3.50</td><td class="dim">3.42</td><td class="dim">38.25</td><td class="dim">49.74</td><td class="dim">72.75</td><td class="dim">59.00</td><td class="dim">36.28</td><td class="dim">59.62</td>
+<td class="overall-score">59.00</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="23" data-overall="57.46">
+<td><span class="rank rank-default" data-orig="23">23</span></td>
+<td class="model-cell"><span class="model-name">Ultravox-v0.5-LLaMA-3.2-1B</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.04</td><td class="dim">3.57</td><td class="dim">3.47</td><td class="dim">34.72</td><td class="dim">30.03</td><td class="dim">35.60</td><td class="dim">52.70</td><td class="dim">45.56</td><td class="dim">96.92</td>
+<td class="overall-score">57.46</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="24" data-overall="57.39">
+<td><span class="rank rank-default" data-orig="24">24</span></td>
+<td class="model-cell"><span class="model-name">DiVA</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.67</td><td class="dim">3.54</td><td class="dim">3.74</td><td class="dim">57.05</td><td class="dim">25.76</td><td class="dim">25.49</td><td class="dim">51.80</td><td class="dim">39.15</td><td class="dim">98.27</td>
+<td class="overall-score">57.39</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="25" data-overall="56.48">
+<td><span class="rank rank-default" data-orig="25">25</span></td>
+<td class="model-cell"><span class="model-name">GLM-4-Voice</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.97</td><td class="dim">3.42</td><td class="dim">3.18</td><td class="dim">36.98</td><td class="dim">39.75</td><td class="dim">53.41</td><td class="dim">52.80</td><td class="dim">25.92</td><td class="dim">88.08</td>
+<td class="overall-score">56.48</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="audiollm" data-open="open" data-rank="26" data-overall="55.80">
+<td><span class="rank rank-default" data-orig="26">26</span></td>
+<td class="model-cell"><span class="model-name">Qwen2-Audio</span><span class="badges"><span class="badge b-allm">Audio-LLM</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.74</td><td class="dim">3.43</td><td class="dim">3.01</td><td class="dim">35.71</td><td class="dim">35.72</td><td class="dim">49.45</td><td class="dim">54.70</td><td class="dim">26.33</td><td class="dim">96.73</td>
+<td class="overall-score">55.80</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr class="row-fd" data-arch="fullduplex" data-open="open" data-rank="27" data-overall="55.20">
+<td><span class="rank rank-default" data-orig="27">27</span></td>
+<td class="model-cell"><span class="model-name">Freeze-Omni</span><span class="badges"><span class="badge b-fd">S2S / Full-Duplex</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.03</td><td class="dim">3.46</td><td class="dim">3.15</td><td class="dim">53.45</td><td class="dim">28.14</td><td class="dim">30.98</td><td class="dim">50.70</td><td class="dim">23.40</td><td class="dim">97.30</td>
+<td class="overall-score">55.20</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="28" data-overall="50.84">
+<td><span class="rank rank-default" data-orig="28">28</span></td>
+<td class="model-cell"><span class="model-name">Step-Audio</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">4.13</td><td class="dim">3.09</td><td class="dim">2.93</td><td class="dim">44.21</td><td class="dim">28.33</td><td class="dim">33.85</td><td class="dim">50.60</td><td class="dim">27.96</td><td class="dim">69.62</td>
+<td class="overall-score">50.84</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="29" data-overall="46.76">
+<td><span class="rank rank-default" data-orig="29">29</span></td>
+<td class="model-cell"><span class="model-name">Megrez-3B-Omni</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.50</td><td class="dim">2.95</td><td class="dim">2.34</td><td class="dim">25.95</td><td class="dim">27.03</td><td class="dim">28.35</td><td class="dim">50.30</td><td class="dim">25.71</td><td class="dim">87.69</td>
+<td class="overall-score">46.76</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="30" data-overall="45.57">
+<td><span class="rank rank-default" data-orig="30">30</span></td>
+<td class="model-cell"><span class="model-name">Ichigo</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.79</td><td class="dim">3.17</td><td class="dim">2.83</td><td class="dim">36.53</td><td class="dim">25.63</td><td class="dim">26.59</td><td class="dim">46.50</td><td class="dim">21.59</td><td class="dim">57.50</td>
+<td class="overall-score">45.57</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="31" data-overall="45.26">
+<td><span class="rank rank-default" data-orig="31">31</span></td>
+<td class="model-cell"><span class="model-name">Lyra-Mini</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">2.99</td><td class="dim">2.69</td><td class="dim">2.58</td><td class="dim">19.89</td><td class="dim">31.42</td><td class="dim">41.54</td><td class="dim">48.40</td><td class="dim">20.91</td><td class="dim">80.00</td>
+<td class="overall-score">45.26</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="32" data-overall="44.59">
+<td><span class="rank rank-default" data-orig="32">32</span></td>
+<td class="model-cell"><span class="model-name">Mair-hub-0.5B-Omni</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.06</td><td class="dim">2.87</td><td class="dim">2.48</td><td class="dim">21.70</td><td class="dim">25.60</td><td class="dim">25.27</td><td class="dim">50.90</td><td class="dim">14.85</td><td class="dim">94.81</td>
+<td class="overall-score">44.59</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="33" data-overall="41.12">
+<td><span class="rank rank-default" data-orig="33">33</span></td>
+<td class="model-cell"><span class="model-name">LLaMA-Omni</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.70</td><td class="dim">3.46</td><td class="dim">2.92</td><td class="dim">39.69</td><td class="dim">25.93</td><td class="dim">27.47</td><td class="dim">49.20</td><td class="dim">14.87</td><td class="dim">11.35</td>
+<td class="overall-score">41.12</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="34" data-overall="36.43">
+<td><span class="rank rank-default" data-orig="34">34</span></td>
+<td class="model-cell"><span class="model-name">VITA-1.0</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">3.38</td><td class="dim">2.15</td><td class="dim">1.87</td><td class="dim">27.94</td><td class="dim">25.70</td><td class="dim">29.01</td><td class="dim">47.70</td><td class="dim">22.82</td><td class="dim">26.73</td>
+<td class="overall-score">36.43</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="35" data-overall="35.30">
+<td><span class="rank rank-default" data-orig="35">35</span></td>
+<td class="model-cell"><span class="model-name">SLAM-Omni</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">1.90</td><td class="dim">1.79</td><td class="dim">1.60</td><td class="dim">4.16</td><td class="dim">26.06</td><td class="dim">25.27</td><td class="dim">48.80</td><td class="dim">13.38</td><td class="dim">94.23</td>
+<td class="overall-score">35.30</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="36" data-overall="33.49">
+<td><span class="rank rank-default" data-orig="36">36</span></td>
+<td class="model-cell"><span class="model-name">Mini-Omni2</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">2.32</td><td class="dim">2.18</td><td class="dim">1.79</td><td class="dim">9.31</td><td class="dim">24.27</td><td class="dim">26.59</td><td class="dim">46.40</td><td class="dim">11.56</td><td class="dim">57.50</td>
+<td class="overall-score">33.49</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr data-arch="omni_hd" data-open="open" data-rank="37" data-overall="30.42">
+<td><span class="rank rank-default" data-orig="37">37</span></td>
+<td class="model-cell"><span class="model-name">Mini-Omni</span><span class="badges"><span class="badge b-omni">Omni</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">1.95</td><td class="dim">2.02</td><td class="dim">1.61</td><td class="dim">13.92</td><td class="dim">24.69</td><td class="dim">26.59</td><td class="dim">46.30</td><td class="dim">13.58</td><td class="dim">37.12</td>
+<td class="overall-score">30.42</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+<tr class="row-fd" data-arch="fullduplex" data-open="open" data-rank="38" data-overall="29.51">
+<td><span class="rank rank-default" data-orig="38">38</span></td>
+<td class="model-cell"><span class="model-name">Moshi</span><span class="badges"><span class="badge b-fd">S2S / Full-Duplex</span><span class="badge b-open">Open</span></span></td>
+<td class="dim">2.01</td><td class="dim">1.60</td><td class="dim">1.30</td><td class="dim">15.64</td><td class="dim">24.04</td><td class="dim">25.93</td><td class="dim">47.40</td><td class="dim">10.12</td><td class="dim">44.23</td>
+<td class="overall-score">29.51</td><td class="cat-rank-cell">&mdash;</td>
+</tr>
+      </tbody>
+    </table>
+    <div class="table-note">
+      Scores from <a href="https://github.com/MatthewCYM/VoiceBench">VoiceBench</a>. Architecture types are community-classified. Submit new results via the <a href="https://github.com/MatthewCYM/VoiceBench/issues">issue tracker</a>.
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="about-card">
+    <h2>About VoiceBench</h2>
+    <p>
+      A comprehensive benchmark for LLM-based voice assistants across <strong>10 evaluation dimensions</strong>,
+      covering diverse speaker characteristics, environmental factors, and content variations.
+      Apache 2.0 &middot; <a href="https://arxiv.org/abs/2410.17196" target="_blank"><strong>ICLR 2025</strong></a>.
+      To submit your model, open an <a href="https://github.com/MatthewCYM/VoiceBench/issues">issue</a> on GitHub.
+    </p>
+    <p style="margin-top:10px;font-size:.82rem;color:#94a3b8">
+      <strong>Architecture types:</strong>
+      <strong style="color:#2563eb">Cascaded</strong> = separate ASR + LLM pipeline &middot;
+      <strong style="color:#d97706">Audio-LLM</strong> = audio encoder fused with LLM, text output only &middot;
+      <strong style="color:#475569">Omni</strong> = end-to-end speech-in speech-out, turn-based &middot;
+      <strong style="color:#059669">S2S / Full-Duplex</strong> = simultaneous listen &amp; speak, no external VAD
+    </p>
+  </div>
+</section>
+</div>
+
+<footer>
+  <div class="container">
+    Data: <a href="https://github.com/MatthewCYM/VoiceBench">VoiceBench</a> &middot;
+    Citation: <a href="https://arxiv.org/abs/2410.17196">Chen et al., 2024</a>
+  </div>
+</footer>
+
+<script>
+(function(){
+  const state = {arch: 'all', open: 'all'};
+  const tbody = document.querySelector('#leaderboard tbody');
+  const summary = document.getElementById('filterSummary');
+  const allRows = Array.from(tbody.querySelectorAll('tr'));
+  const pillAll = document.getElementById('pill-all');
+  const pillOpen = document.getElementById('pill-open');
+  const pillClosed = document.getElementById('pill-closed');
+
+  function updatePillCounts() {
+    let total = 0, open = 0, closed = 0;
+    allRows.forEach(row => {
+      if (state.arch === 'all' || row.dataset.arch === state.arch) {
+        total++;
+        if (row.dataset.open === 'open') open++; else closed++;
+      }
+    });
+    pillAll.textContent = 'All (' + total + ')';
+    pillOpen.textContent = 'Open (' + open + ')';
+    pillClosed.textContent = 'Closed (' + closed + ')';
+    pillClosed.style.opacity = closed === 0 ? '.4' : '1';
+    pillClosed.style.pointerEvents = closed === 0 ? 'none' : 'auto';
+    pillOpen.style.opacity = open === 0 ? '.4' : '1';
+    pillOpen.style.pointerEvents = open === 0 ? 'none' : 'auto';
+  }
+
+  document.querySelectorAll('.fc').forEach(c => {
+    c.addEventListener('click', () => {
+      document.querySelectorAll('.fc').forEach(x => x.classList.remove('active'));
+      c.classList.add('active');
+      state.arch = c.dataset.arch;
+      state.open = 'all';
+      document.querySelectorAll('.pill').forEach(x => x.classList.remove('active'));
+      pillAll.classList.add('active');
+      updatePillCounts();
+      applyFilters();
+    });
+  });
+
+  document.querySelectorAll('.pill').forEach(p => {
+    p.addEventListener('click', () => {
+      if (p.style.pointerEvents === 'none') return;
+      document.querySelectorAll('.pill').forEach(x => x.classList.remove('active'));
+      p.classList.add('active');
+      state.open = p.dataset.val;
+      applyFilters();
+    });
+  });
+
+  function applyFilters() {
+    const visible = [];
+    const isFiltered = state.arch !== 'all' || state.open !== 'all';
+    allRows.forEach(row => {
+      const matchArch = state.arch === 'all' || row.dataset.arch === state.arch;
+      const matchOpen = state.open === 'all' || row.dataset.open === state.open;
+      if (matchArch && matchOpen) { row.classList.remove('hidden'); visible.push(row); }
+      else { row.classList.add('hidden'); }
+    });
+    visible.sort((a, b) => parseFloat(b.dataset.overall) - parseFloat(a.dataset.overall));
+    visible.forEach((row, i) => {
+      const catCell = row.querySelector('.cat-rank-cell');
+      const rankSpan = row.querySelector('.rank');
+      const origRank = rankSpan.dataset.orig;
+      if (!isFiltered) {
+        catCell.innerHTML = '<span style="color:#cbd5e1">&mdash;</span>';
+        rankSpan.textContent = origRank;
+        rankSpan.className = 'rank ' + getRankClass(parseInt(origRank), row);
+      } else {
+        const n = i + 1;
+        catCell.innerHTML = '<span class="cr-cat">#' + n + '</span><span class="cr-sep">/</span><span class="cr-orig">#' + origRank + ' overall</span>';
+        rankSpan.textContent = n;
+        rankSpan.className = 'rank ' + getRankClass(n, row);
+      }
+    });
+    if (!isFiltered) { summary.style.display = 'none'; }
+    else {
+      summary.style.display = 'block';
+      const labels = {all:'All', fullduplex:'S2S / Full-Duplex', cascaded:'Cascaded', audiollm:'Audio-LLM', omni_hd:'Omni', open:'Open-Source', closed:'Closed'};
+      let label = '';
+      if (state.arch !== 'all' && state.open !== 'all') label = labels[state.open] + ' ' + labels[state.arch];
+      else if (state.arch !== 'all') label = labels[state.arch];
+      else label = labels[state.open];
+      summary.innerHTML = '<strong>' + visible.length + '</strong> ' + label + ' models shown';
+    }
+  }
+
+  function getRankClass(n, row) {
+    if (n === 1) return 'rank-1';
+    if (n === 2) return 'rank-2';
+    if (n === 3) return 'rank-3';
+    return 'rank-default';
+  }
+
+  updatePillCounts();
+  applyFilters();
+})();
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,6 +114,10 @@ section{padding:32px 0}section+section{padding-top:0}
 .about-card{background:#fff;border:1px solid #e2e8f0;border-radius:10px;padding:20px 24px}
 .about-card h2{font-size:1.1rem;font-weight:700;margin-bottom:8px;color:#0f172a}
 .about-card p{color:#475569;font-size:.88rem;line-height:1.7}
+.citation-inline{margin-top:18px;padding-top:16px;border-top:1px solid #e2e8f0}
+.citation-inline h3{font-size:.98rem;font-weight:700;margin-bottom:8px;color:#0f172a}
+.citation-inline .citation-note{margin-bottom:10px;font-size:.86rem;color:#475569}
+.citation-inline pre{background:#0f172a;color:#e2e8f0;padding:16px;border-radius:12px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-size:.88rem;line-height:1.5}
 
 /* Legend */
 .legend{display:flex;flex-wrap:wrap;gap:16px;margin-bottom:14px;font-size:.75rem;color:#64748b}
@@ -140,7 +144,7 @@ footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.
     <p class="sub">Benchmarking LLM-Based Voice Assistants &middot; 38 Models &middot; 4 Architecture Types &middot; Click cards to filter</p>
     <div class="links">
       <a class="primary" href="https://github.com/MatthewCYM/VoiceBench" target="_blank">GitHub &rarr;</a>
-      <a class="secondary" href="https://arxiv.org/abs/2410.17196" target="_blank">Paper (TACL) &rarr;</a>
+      <a class="secondary" href="https://arxiv.org/abs/2410.17196" target="_blank">Paper &rarr;</a>
       <a class="secondary" href="https://huggingface.co/datasets/hlt-lab/voicebench" target="_blank">Dataset &rarr;</a>
     </div>
   </div>
@@ -453,9 +457,8 @@ footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.
   <div class="about-card">
     <h2>About VoiceBench</h2>
     <p>
-      A comprehensive benchmark for LLM-based voice assistants across <strong>10 evaluation dimensions</strong>,
+      A comprehensive benchmark for LLM-based voice assistants across <strong>9 evaluation datasets</strong>,
       covering diverse speaker characteristics, environmental factors, and content variations.
-      Apache 2.0 &middot; <a href="https://arxiv.org/abs/2410.17196" target="_blank"><strong>TACL</strong></a>.
       To submit your model, open an <a href="https://github.com/MatthewCYM/VoiceBench/issues">issue</a> on GitHub.
     </p>
     <p style="margin-top:10px;font-size:.82rem;color:#94a3b8">
@@ -465,6 +468,16 @@ footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.
       <strong style="color:#475569">Omni</strong> = end-to-end speech-in speech-out, turn-based &middot;
       <strong style="color:#059669">S2S / Full-Duplex</strong> = simultaneous listen &amp; speak, no external VAD
     </p>
+    <div class="citation-inline">
+      <h3>Citation</h3>
+      <p class="citation-note">If you use <strong>VoiceBench</strong> in your research, please cite the following paper:</p>
+      <pre>@article{chen2024voicebench,
+  title={VoiceBench: Benchmarking LLM-Based Voice Assistants},
+  author={Chen, Yiming and Yue, Xianghu and Zhang, Chen and Gao, Xiaoxue and Tan, Robby T. and Li, Haizhou},
+  journal={arXiv preprint arXiv:2410.17196},
+  year={2024}
+}</pre>
+    </div>
   </div>
 </section>
 </div>
@@ -574,5 +587,6 @@ footer{border-top:1px solid #e2e8f0;padding:20px 0;text-align:center;font-size:.
   applyFilters();
 })();
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds an interactive HTML leaderboard page (`docs/index.html`) that enhances the existing README table with model architecture classification and filtering capabilities.

**Live preview**: Open `docs/index.html` locally or enable [GitHub Pages](https://docs.github.com/en/pages) pointing to `/docs`.

### What's added

- **Architecture classification** for all 38 models into 4 types:
  - **Cascaded** (5) — separate ASR + LLM pipeline (e.g., Whisper + GPT-4o)
  - **Audio-LLM** (11) — audio encoder fused with LLM, text output (e.g., Ultravox)
  - **Omni** (20) — end-to-end speech-in/speech-out, turn-based (e.g., GPT-4o-Audio)
  - **S2S / Full-Duplex** (2) — simultaneous listen & speak (e.g., Freeze-Omni, Moshi)

- **Interactive filter cards** — click any architecture type to filter the table and see within-category rankings

- **Open/Closed toggle** — filter models by weight availability (35 open, 3 closed)

- **Color-coded badges** on each model row for quick visual identification of architecture type and weight availability

- **Dynamic re-ranking** — when filtered, shows both category rank and overall rank

### Design decisions

- Self-contained single HTML file, zero external dependencies
- All scores match the current README leaderboard exactly
- Fixed the duplicate rank numbering in positions 10-11 (38 unique models, now ranked 1-38)
- Neutral, generic design — no vendor-specific branding or highlighting
- Responsive layout works on mobile

### Screenshot

The page features clickable category cards at the top, open/closed filter pills, a color legend, and the full leaderboard table with architecture badges.

### How to use

Option A: Open `docs/index.html` directly in a browser
Option B: Enable GitHub Pages → Settings → Pages → Source: Deploy from branch, folder: `/docs`